### PR TITLE
fix: fix aminoType of MsgTransfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc --module commonjs",

--- a/src/ibc/applications/nft-transfer/tx.ts
+++ b/src/ibc/applications/nft-transfer/tx.ts
@@ -19,7 +19,7 @@ export const registry: readonly [string, GeneratedType][] = [
 // amino converters
 export const aminoConverters: AminoConverters = {
   '/ibc.applications.nft_transfer.v1.MsgTransfer': {
-    aminoType: 'nft_transfer/MsgTransfer',
+    aminoType: 'nft-transfer/MsgTransfer',
     toAmino: (msg: MsgTransfer): MsgNftTransferAmino => ({
       source_port: msg.sourcePort,
       source_channel: msg.sourceChannel,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the identifier used for NFT transfer messages to improve compatibility with amino encoding and decoding.
- **Chores**
	- Updated the package version to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->