### PR TITLE
fix: change peer-dependency version to `>=0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/amino-converter",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@initia/initia.proto": "^0.2.4",
@@ -21,9 +21,9 @@
         "typescript-eslint": "^8.15.0"
       },
       "peerDependencies": {
-        "@cosmjs/cosmwasm-stargate": "^0.33.1",
-        "@cosmjs/proto-signing": "^0.33.1",
-        "@cosmjs/stargate": "^0.33.1"
+        "@cosmjs/cosmwasm-stargate": "^0",
+        "@cosmjs/proto-signing": "^0",
+        "@cosmjs/stargate": "^0"
       }
     },
     "node_modules/@cosmjs/amino": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc --module commonjs",
@@ -27,9 +27,9 @@
     "@initia/opinit.proto": "^0.0.11"
   },
   "peerDependencies": {
-    "@cosmjs/cosmwasm-stargate": "^0.32.4",
-    "@cosmjs/proto-signing": "^0.32.4",
-    "@cosmjs/stargate": "^0.32.4"
+    "@cosmjs/cosmwasm-stargate": "^0",
+    "@cosmjs/proto-signing": "^0",
+    "@cosmjs/stargate": "^0"
   },
   "lint-staged": {
     "src/**/*.{mjs|ts}": [

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "@initia/opinit.proto": "^0.0.11"
   },
   "peerDependencies": {
-    "@cosmjs/cosmwasm-stargate": "^0",
-    "@cosmjs/proto-signing": "^0",
-    "@cosmjs/stargate": "^0"
+    "@cosmjs/cosmwasm-stargate": ">=0",
+    "@cosmjs/proto-signing": ">=0",
+    "@cosmjs/stargate": ">=0"
   },
   "lint-staged": {
     "src/**/*.{mjs|ts}": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.0.4.
  * Broadened compatibility for certain peer dependencies, allowing support for any 0.x.x version of key CosmJS packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->