### PR TITLE
fix: resolve ESM import issues and bump version to 1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@initia/opinit.proto": "^1.0.2"
       },
       "devDependencies": {
+        "@types/node": "^24.2.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "husky": "^9.1.7",
@@ -1361,6 +1362,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.15.0",
@@ -4411,6 +4422,13 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -21,6 +21,7 @@
     "dist"
   ],
   "devDependencies": {
+    "@types/node": "^24.2.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "husky": "^9.1.7",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'path'
+import { readFile, writeFile } from 'fs/promises'
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
@@ -8,4 +10,50 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   splitting: false,
+
+  // Fix imports: Node.js requires .js extensions for ES modules
+  // The @initia proto packages export without extensions, causing module resolution errors
+  async onSuccess() {
+    try {
+      const esmFile = resolve('./dist/index.mjs')
+      const content = await readFile(esmFile, 'utf-8')
+
+      // Packages that need .js extensions added to their imports
+      const targetPackages = ['@initia/initia.proto', '@initia/opinit.proto']
+
+      // Create regex pattern from target packages
+      const escapedPackages = targetPackages.map((pkg) =>
+        pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      )
+      const packagePattern = escapedPackages.join('|')
+
+      // Match import statements with captured groups for quote style and path
+      // Group 1: opening quote (' or ")
+      // Group 2: the full path including package name
+      // Group 3: closing quote (same as opening)
+      const regex = new RegExp(
+        `from\\s+(['"])((?:${packagePattern})/[^'"]+)(['"])`,
+        'g'
+      )
+
+      // Add .js extension to matching imports, preserving quote style
+      const modifiedContent = content.replace(
+        regex,
+        (match, openQuote, path, closeQuote) => {
+          // Skip if already ends with .js
+          if (path.endsWith('.js')) {
+            return match
+          }
+          // Return with .js extension and preserved quote style
+          return `from ${openQuote}${path}.js${closeQuote}`
+        }
+      )
+
+      await writeFile(esmFile, modifiedContent)
+      console.log('✅ Fixed imports by adding .js extensions')
+    } catch (error) {
+      console.error('❌ Failed to fix imports:', error)
+      process.exit(1)
+    }
+  },
 })


### PR DESCRIPTION
## Summary
- Fixed ES module import paths for @initia proto packages by adding .js extensions
- Added @types/node as dev dependency for Node.js types
- Bumped version to 1.0.6

## Problem
The library was failing to resolve imports in ESM environments because Node.js requires explicit `.js` extensions for ES modules, but the @initia proto packages export their modules without extensions.

## Solution
Implemented a post-build script in `tsup.config.ts` that automatically adds `.js` extensions to all imports from @initia proto packages in the ESM build output.

## Changes
- Modified `tsup.config.ts` to add an `onSuccess` hook that processes the ESM output
- The hook adds `.js` extensions to imports from `@initia/initia.proto` and `@initia/opinit.proto`
- Added `@types/node` for proper TypeScript types in the build configuration
- Version bump to 1.0.6

## Test Plan
- [ ] Build the library using `npm run build`
- [ ] Verify that `dist/index.mjs` contains imports with `.js` extensions
- [ ] Test importing the library in an ESM project
- [ ] Ensure the library works correctly in both ESM and CJS environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for ESM consumers by ensuring built bundles use explicit .js import extensions to avoid module resolution errors at runtime.

- **Chores**
  - Bumped package version to 1.0.6.
  - Added Node.js type definitions as a development dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->