### PR TITLE
fix: switch to CommonJS build for proto package compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/amino-converter",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.34.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,8 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.5",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    }
-  },
+  "version": "1.0.6",
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
   "scripts": {
     "build": "tsup",
     "lint": "npx eslint . --fix",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,8 +1,23 @@
 import { defineConfig } from 'tsup'
 
+// IMPORTANT: Building as CommonJS only for compatibility with @initia proto packages
+//
+// The @initia/initia.proto and @initia/opinit.proto packages are built as CommonJS modules
+// with .js extensions. When this package is built as ESM, Node.js ESM loader attempts to
+// import these .js files as ES modules, but they contain CommonJS syntax (module.exports),
+// causing "Cannot use import statement outside a module" or similar errors.
+//
+// Even with explicit .js extensions in imports, the module format mismatch persists because:
+// 1. Proto packages don't declare "type": "module" in package.json
+// 2. Generated files use CommonJS exports (exports.xxx = ...) not ES exports
+// 3. Different bundlers (Webpack, Vite, esbuild) interpret .js files inconsistently
+//
+// Using CommonJS ensures consistent behavior across all environments and avoids the
+// dual package hazard where ESM consumers would fail at runtime.
+
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['cjs'],
   dts: true,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
## Summary
- Switch from dual ESM/CJS build to CommonJS-only build
- Add detailed documentation explaining the technical reasons
- Resolve module format compatibility issues with @initia proto packages

## Problem
The @initia/initia.proto and @initia/opinit.proto packages are built as CommonJS modules. When amino-converter was built as ESM, it caused runtime errors due to module format mismatches:

1. Proto packages generate `.js` files with CommonJS syntax (`module.exports`)
2. ESM imports would interpret these as ES modules, causing failures
3. Even with explicit `.js` extensions, the format mismatch persisted
4. Different bundlers (Webpack, Vite, esbuild) handle the ambiguity inconsistently

## Solution
Building amino-converter as CommonJS-only ensures:
- Consistent module resolution across all environments
- No dual package hazard for consuming projects
- Reliable interoperability with proto packages

## Changes
- Changed tsup config to build CJS format only
- Updated package.json exports to use simple `main` field
- Added comprehensive comments explaining the decision

## Test plan
- [ ] Build succeeds with `npm run build`
- [ ] Generated output is CommonJS format
- [ ] TypeScript definitions are properly generated
- [ ] Test integration with consuming projects
- [ ] Verify no runtime errors with proto imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Build
  - Switched to a CommonJS-only distribution, removing the dual ESM/CJS output.
  - Standardized public entry points with a single main entry and bundled TypeScript definitions.
  - No runtime behavior changes expected for CommonJS consumers; improved IDE typings out of the box.
- Chores
  - Bumped version to 1.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->