### PR TITLE
fix: omit empty minievm MsgCall access_list while preserving null compatability

### DIFF
--- a/src/minievm/evm/v1/tx.aminoTypes.ts
+++ b/src/minievm/evm/v1/tx.aminoTypes.ts
@@ -20,7 +20,7 @@ export interface MsgCallAmino {
   contract_addr: string
   input: string
   value: string
-  access_list: AccessTupleAmino[] | null
+  access_list?: AccessTupleAmino[] | null
 }
 
 export interface MsgUpdateParamsAmino {

--- a/src/minievm/evm/v1/tx.ts
+++ b/src/minievm/evm/v1/tx.ts
@@ -88,7 +88,7 @@ export const aminoConverters: AminoConverters = {
       value: msg.value,
       access_list:
         msg.accessList.length === 0
-          ? null
+          ? undefined
           : msg.accessList.map((accessTuple) =>
               AccessTuple.toAmino(accessTuple)
             ),


### PR DESCRIPTION
This fixes how MiniEVM MsgCall handles an empty `access_list` during Amino conversion.

Before this change, an empty list was encoded as null. After this change, it is simply left out. When reading Amino back in, a missing `access_list` still becomes an empty array, so existing behavior stays compatible.

Why this matters:

- MiniEVM autosign expects a consistent transaction shape when building the message to sign
- encoding an empty access_list as null can produce a different shape than expected
- leaving it out avoids that mismatch

Why this is safe:

- only MiniEVM MsgCall is affected
- non-empty access_list values are unchanged
- older inputs still decode correctly
- Move and Wasm flows are untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified transaction message construction by making the access list parameter optional, allowing developers to omit it when not required
  * Enhanced serialization handling to properly manage cases where access lists are not provided, ensuring consistent message processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->