### PR TITLE
fix: default minievm MsgCall authList to empty array on amino decode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "repository": {

--- a/src/minievm/evm/v1/tx.aminoTypes.ts
+++ b/src/minievm/evm/v1/tx.aminoTypes.ts
@@ -1,4 +1,8 @@
-import { AccessTupleAmino, ParamsAmino } from './types'
+import {
+  AccessTupleAmino,
+  ParamsAmino,
+  SetCodeAuthorizationAmino,
+} from './types'
 
 export interface MsgCreateAmino {
   sender: string
@@ -20,6 +24,7 @@ export interface MsgCallAmino {
   contract_addr: string
   input: string
   value: string
+  auth_list: SetCodeAuthorizationAmino[] | null
   access_list: AccessTupleAmino[] | null
 }
 

--- a/src/minievm/evm/v1/tx.ts
+++ b/src/minievm/evm/v1/tx.ts
@@ -98,6 +98,7 @@ export const aminoConverters: AminoConverters = {
       contractAddr: msg.contract_addr,
       input: msg.input,
       value: msg.value,
+      authList: [],
       accessList: msg.access_list
         ? msg.access_list.map((accessTuple) =>
             AccessTuple.fromAmino(accessTuple)

--- a/src/minievm/evm/v1/tx.ts
+++ b/src/minievm/evm/v1/tx.ts
@@ -14,7 +14,7 @@ import {
   MsgUpdateParamsAmino,
 } from './tx.aminoTypes'
 import { Params as Params_pb } from '@initia/initia.proto/minievm/evm/v1/types'
-import { AccessTuple, Params } from './types'
+import { AccessTuple, Params, SetCodeAuthorization } from './types'
 
 // registry
 
@@ -86,6 +86,12 @@ export const aminoConverters: AminoConverters = {
       contract_addr: msg.contractAddr,
       input: msg.input,
       value: msg.value,
+      auth_list:
+        msg.accessList.length === 0
+          ? null
+          : msg.authList.map((setCodeAuthorization) =>
+              SetCodeAuthorization.toAmino(setCodeAuthorization)
+            ),
       access_list:
         msg.accessList.length === 0
           ? null
@@ -98,7 +104,11 @@ export const aminoConverters: AminoConverters = {
       contractAddr: msg.contract_addr,
       input: msg.input,
       value: msg.value,
-      authList: [],
+      authList: msg.auth_list
+        ? msg.auth_list.map((setCodeAuthorization) =>
+            SetCodeAuthorization.fromAmino(setCodeAuthorization)
+          )
+        : [],
       accessList: msg.access_list
         ? msg.access_list.map((accessTuple) =>
             AccessTuple.fromAmino(accessTuple)

--- a/src/minievm/evm/v1/types.ts
+++ b/src/minievm/evm/v1/types.ts
@@ -1,7 +1,9 @@
 import {
   AccessTuple as AccessTuple_pb,
   Params as Params_pb,
+  SetCodeAuthorization as SetCodeAuthorization_pb,
 } from '@initia/initia.proto/minievm/evm/v1/types'
+import { base64ToBytes, bytesToBase64 } from '../../../utils'
 
 export const Params = {
   toAmino: (params: Params_pb): ParamsAmino => ({
@@ -46,6 +48,26 @@ export const AccessTuple = {
   }),
 }
 
+export const SetCodeAuthorization = {
+  toAmino: (
+    accessTuple: SetCodeAuthorization_pb
+  ): SetCodeAuthorizationAmino => ({
+    chain_id: accessTuple.chainId,
+    address: accessTuple.address,
+    nonce: accessTuple.nonce.toString(),
+    signature: bytesToBase64(accessTuple.signature),
+  }),
+
+  fromAmino: (
+    accessTuple: SetCodeAuthorizationAmino
+  ): SetCodeAuthorization_pb => ({
+    chainId: accessTuple.chain_id,
+    address: accessTuple.address,
+    nonce: BigInt(accessTuple.nonce),
+    signature: base64ToBytes(accessTuple.signature),
+  }),
+}
+
 export interface ParamsAmino {
   extra_eips?: string[]
   allowed_publishers: string[] | null
@@ -59,4 +81,11 @@ export interface ParamsAmino {
 export interface AccessTupleAmino {
   address: string
   storage_keys?: string[]
+}
+
+export interface SetCodeAuthorizationAmino {
+  chain_id: string
+  address: string
+  nonce: string
+  signature: string
 }


### PR DESCRIPTION
This defaults missing `MsgCall.authList` to `[]` during Amino decode. That prevents MiniEVM autosign from failing with `authList is not iterable` while leaving any existing populated value unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extended transaction authorization information, enabling improved processing of transaction permissions and validation signatures.

* **Chores**
  * Version updated to 1.0.17

<!-- end of auto-generated comment: release notes by coderabbit.ai -->