### PR TITLE
fix: remove minievm MsgCall auth_list amino encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "repository": {

--- a/src/minievm/evm/v1/tx.aminoTypes.ts
+++ b/src/minievm/evm/v1/tx.aminoTypes.ts
@@ -24,7 +24,7 @@ export interface MsgCallAmino {
   contract_addr: string
   input: string
   value: string
-  auth_list: SetCodeAuthorizationAmino[] | null
+  auth_list?: SetCodeAuthorizationAmino[]
   access_list: AccessTupleAmino[] | null
 }
 

--- a/src/minievm/evm/v1/tx.ts
+++ b/src/minievm/evm/v1/tx.ts
@@ -86,6 +86,12 @@ export const aminoConverters: AminoConverters = {
       contract_addr: msg.contractAddr,
       input: msg.input,
       value: msg.value,
+      auth_list:
+        msg.accessList.length === 0
+          ? undefined
+          : msg.authList.map((setCodeAuthorization) =>
+              SetCodeAuthorization.toAmino(setCodeAuthorization)
+            ),
       access_list:
         msg.accessList.length === 0
           ? null

--- a/src/minievm/evm/v1/tx.ts
+++ b/src/minievm/evm/v1/tx.ts
@@ -86,12 +86,6 @@ export const aminoConverters: AminoConverters = {
       contract_addr: msg.contractAddr,
       input: msg.input,
       value: msg.value,
-      auth_list:
-        msg.accessList.length === 0
-          ? null
-          : msg.authList.map((setCodeAuthorization) =>
-              SetCodeAuthorization.toAmino(setCodeAuthorization)
-            ),
       access_list:
         msg.accessList.length === 0
           ? null


### PR DESCRIPTION
This removes `auth_list` from MiniEVM `MsgCall` Amino encoding. Emitting that field changed the signed payload shape and caused MiniEVM autosign signature verification to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transactions now omit an empty authorization list when encoding, reducing payload size.
  * Decoding remains backward compatible and still accepts previously encoded transactions that include the field.

* **Chores**
  * Package version updated (patch release).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->