### PR TITLE
fix: replace spread-based base64 with @cosmjs/encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.16",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@initia/amino-converter",
-      "version": "1.0.16",
+      "version": "1.0.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.36.0",
+        "@cosmjs/encoding": "^0.36.0",
         "@cosmjs/proto-signing": "^0.36.0",
         "@cosmjs/stargate": "^0.36.0",
         "@initia/initia.proto": "^1.0.3",
@@ -26,6 +27,7 @@
       },
       "peerDependencies": {
         "@cosmjs/cosmwasm-stargate": ">=0.36.0",
+        "@cosmjs/encoding": ">=0.36.0",
         "@cosmjs/proto-signing": ">=0.36.0",
         "@cosmjs/stargate": ">=0.36.0",
         "@initia/initia.proto": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@initia/amino-converter",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "repository": {
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.36.0",
+    "@cosmjs/encoding": "^0.36.0",
     "@cosmjs/proto-signing": "^0.36.0",
     "@cosmjs/stargate": "^0.36.0",
     "@initia/initia.proto": "^1.0.3",
@@ -37,6 +38,7 @@
   },
   "peerDependencies": {
     "@cosmjs/cosmwasm-stargate": ">=0.36.0",
+    "@cosmjs/encoding": ">=0.36.0",
     "@cosmjs/proto-signing": ">=0.36.0",
     "@cosmjs/stargate": ">=0.36.0",
     "@initia/initia.proto": ">=1.0.0",

--- a/src/cosmos/crypto/ed25519/keys.ts
+++ b/src/cosmos/crypto/ed25519/keys.ts
@@ -1,12 +1,12 @@
 import { PubKey as PubKey_pb } from '@initia/initia.proto/cosmos/crypto/ed25519/keys'
-import { base64ToBytes, bytesToBase64 } from '../../../utils'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 
 export const PubKey = {
   toAmino: (pubKey: PubKey_pb): PubKeyAmino => ({
-    key: bytesToBase64(pubKey.key),
+    key: toBase64(pubKey.key),
   }),
   fromAmino: (pubKey: PubKeyAmino): PubKey_pb => ({
-    key: base64ToBytes(pubKey.key),
+    key: fromBase64(pubKey.key),
   }),
   toProtoMsg: (pubKey: PubKey_pb): PubKeyProtoMsg => ({
     typeUrl: '/cosmos.crypto.ed25519.PubKey',
@@ -20,7 +20,7 @@ export const PubKey = {
     value: PubKey.toAmino(pubKey).key,
   }),
   fromAminoMsg: (pubKey: PubKeyAminoMsg): PubKey_pb => ({
-    key: base64ToBytes(pubKey.value),
+    key: fromBase64(pubKey.value),
   }),
 }
 

--- a/src/initia/move/v1/tx.ts
+++ b/src/initia/move/v1/tx.ts
@@ -14,7 +14,7 @@ import {
   MsgDelist,
   MsgUpdateParams,
 } from '@initia/initia.proto/initia/move/v1/tx'
-import { base64ToBytes, bytesToBase64 } from '../../../utils'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import {
   MsgDelistAmino,
   MsgExecuteAmino,
@@ -64,7 +64,7 @@ export const aminoConverters: AminoConverters = {
       code_bytes:
         msg.codeBytes.length === 0
           ? undefined
-          : msg.codeBytes.map((bytes) => bytesToBase64(bytes)),
+          : msg.codeBytes.map((bytes) => toBase64(bytes)),
       upgrade_policy:
         msg.upgradePolicy === UpgradePolicy.UNSPECIFIED
           ? undefined
@@ -73,7 +73,7 @@ export const aminoConverters: AminoConverters = {
     fromAmino: (msg: MsgPublishAmino): MsgPublish => ({
       sender: msg.sender,
       codeBytes: msg.code_bytes
-        ? msg.code_bytes.map((str) => base64ToBytes(str))
+        ? msg.code_bytes.map((str) => fromBase64(str))
         : [],
       upgradePolicy: msg.upgrade_policy ?? UpgradePolicy.UNSPECIFIED,
     }),
@@ -89,7 +89,7 @@ export const aminoConverters: AminoConverters = {
       args:
         msg.args.length === 0
           ? undefined
-          : msg.args.map((bytes) => bytesToBase64(bytes)),
+          : msg.args.map((bytes) => toBase64(bytes)),
     }),
     fromAmino: (msg: MsgExecuteAmino): MsgExecute => ({
       sender: msg.sender,
@@ -97,7 +97,7 @@ export const aminoConverters: AminoConverters = {
       moduleName: msg.module_name,
       functionName: msg.function_name,
       typeArgs: msg.type_args ?? [],
-      args: msg.args ? msg.args.map((arg) => base64ToBytes(arg)) : [],
+      args: msg.args ? msg.args.map((arg) => fromBase64(arg)) : [],
     }),
   },
   '/initia.move.v1.MsgExecuteJSON': {
@@ -123,31 +123,31 @@ export const aminoConverters: AminoConverters = {
     aminoType: 'move/MsgScript',
     toAmino: (msg: MsgScript): MsgScriptAmino => ({
       sender: msg.sender,
-      code_bytes: bytesToBase64(msg.codeBytes),
+      code_bytes: toBase64(msg.codeBytes),
       type_args: msg.typeArgs.length === 0 ? undefined : msg.typeArgs,
       args:
         msg.args.length === 0
           ? undefined
-          : msg.args.map((bytes) => bytesToBase64(bytes)),
+          : msg.args.map((bytes) => toBase64(bytes)),
     }),
     fromAmino: (msg: MsgScriptAmino): MsgScript => ({
       sender: msg.sender,
-      codeBytes: base64ToBytes(msg.code_bytes),
+      codeBytes: fromBase64(msg.code_bytes),
       typeArgs: msg.type_args ?? [],
-      args: msg.args ? msg.args.map((arg) => base64ToBytes(arg)) : [],
+      args: msg.args ? msg.args.map((arg) => fromBase64(arg)) : [],
     }),
   },
   '/initia.move.v1.MsgScriptJSON': {
     aminoType: 'move/MsgScriptJSON',
     toAmino: (msg: MsgScriptJSON): MsgScriptJSONAmino => ({
       sender: msg.sender,
-      code_bytes: bytesToBase64(msg.codeBytes),
+      code_bytes: toBase64(msg.codeBytes),
       type_args: msg.typeArgs.length === 0 ? undefined : msg.typeArgs,
       args: msg.args.length === 0 ? undefined : msg.args,
     }),
     fromAmino: (msg: MsgScriptJSONAmino): MsgScriptJSON => ({
       sender: msg.sender,
-      codeBytes: base64ToBytes(msg.code_bytes),
+      codeBytes: fromBase64(msg.code_bytes),
       typeArgs: msg.type_args ?? [],
       args: msg.args ?? [],
     }),
@@ -160,7 +160,7 @@ export const aminoConverters: AminoConverters = {
       code_bytes:
         msg.codeBytes.length === 0
           ? undefined
-          : msg.codeBytes.map((bytes) => bytesToBase64(bytes)),
+          : msg.codeBytes.map((bytes) => toBase64(bytes)),
       upgrade_policy:
         msg.upgradePolicy === UpgradePolicy.UNSPECIFIED
           ? undefined
@@ -170,7 +170,7 @@ export const aminoConverters: AminoConverters = {
       authority: msg.authority,
       sender: msg.sender,
       codeBytes: msg.code_bytes
-        ? msg.code_bytes.map((str) => base64ToBytes(str))
+        ? msg.code_bytes.map((str) => fromBase64(str))
         : [],
       upgradePolicy: msg.upgrade_policy ?? UpgradePolicy.UNSPECIFIED,
     }),
@@ -187,7 +187,7 @@ export const aminoConverters: AminoConverters = {
       args:
         msg.args.length === 0
           ? undefined
-          : msg.args.map((bytes) => bytesToBase64(bytes)),
+          : msg.args.map((bytes) => toBase64(bytes)),
     }),
     fromAmino: (msg: MsgGovExecuteAmino): MsgGovExecute => ({
       authority: msg.authority,
@@ -196,7 +196,7 @@ export const aminoConverters: AminoConverters = {
       moduleName: msg.module_name,
       functionName: msg.function_name,
       typeArgs: msg.type_args ?? [],
-      args: msg.args ? msg.args.map((arg) => base64ToBytes(arg)) : [],
+      args: msg.args ? msg.args.map((arg) => fromBase64(arg)) : [],
     }),
   },
   '/initia.move.v1.MsgGovExecuteJSON': {
@@ -225,19 +225,19 @@ export const aminoConverters: AminoConverters = {
     toAmino: (msg: MsgGovScript): MsgGovScriptAmino => ({
       authority: msg.authority,
       sender: msg.sender,
-      code_bytes: bytesToBase64(msg.codeBytes),
+      code_bytes: toBase64(msg.codeBytes),
       type_args: msg.typeArgs.length === 0 ? undefined : msg.typeArgs,
       args:
         msg.args.length === 0
           ? undefined
-          : msg.args.map((bytes) => bytesToBase64(bytes)),
+          : msg.args.map((bytes) => toBase64(bytes)),
     }),
     fromAmino: (msg: MsgGovScriptAmino): MsgGovScript => ({
       authority: msg.authority,
       sender: msg.sender,
-      codeBytes: base64ToBytes(msg.code_bytes),
+      codeBytes: fromBase64(msg.code_bytes),
       typeArgs: msg.type_args ?? [],
-      args: msg.args ? msg.args.map((arg) => base64ToBytes(arg)) : [],
+      args: msg.args ? msg.args.map((arg) => fromBase64(arg)) : [],
     }),
   },
   '/initia.move.v1.MsgGovScriptJSON': {
@@ -245,14 +245,14 @@ export const aminoConverters: AminoConverters = {
     toAmino: (msg: MsgGovScriptJSON): MsgGovScriptJSONAmino => ({
       authority: msg.authority,
       sender: msg.sender,
-      code_bytes: bytesToBase64(msg.codeBytes),
+      code_bytes: toBase64(msg.codeBytes),
       type_args: msg.typeArgs.length === 0 ? undefined : msg.typeArgs,
       args: msg.args.length === 0 ? undefined : msg.args,
     }),
     fromAmino: (msg: MsgGovScriptJSONAmino): MsgGovScriptJSON => ({
       authority: msg.authority,
       sender: msg.sender,
-      codeBytes: base64ToBytes(msg.code_bytes),
+      codeBytes: fromBase64(msg.code_bytes),
       typeArgs: msg.type_args ?? [],
       args: msg.args ?? [],
     }),

--- a/src/minievm/evm/v1/types.ts
+++ b/src/minievm/evm/v1/types.ts
@@ -3,7 +3,7 @@ import {
   Params as Params_pb,
   SetCodeAuthorization as SetCodeAuthorization_pb,
 } from '@initia/initia.proto/minievm/evm/v1/types'
-import { base64ToBytes, bytesToBase64 } from '../../../utils'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 
 export const Params = {
   toAmino: (params: Params_pb): ParamsAmino => ({
@@ -55,7 +55,7 @@ export const SetCodeAuthorization = {
     chain_id: accessTuple.chainId,
     address: accessTuple.address,
     nonce: accessTuple.nonce.toString(),
-    signature: bytesToBase64(accessTuple.signature),
+    signature: toBase64(accessTuple.signature),
   }),
 
   fromAmino: (
@@ -64,7 +64,7 @@ export const SetCodeAuthorization = {
     chainId: accessTuple.chain_id,
     address: accessTuple.address,
     nonce: BigInt(accessTuple.nonce),
-    signature: base64ToBytes(accessTuple.signature),
+    signature: fromBase64(accessTuple.signature),
   }),
 }
 

--- a/src/miniwasm/wasm/v1/authz.ts
+++ b/src/miniwasm/wasm/v1/authz.ts
@@ -12,7 +12,7 @@ import {
   AcceptedMessagesFilter,
 } from '@initia/initia.proto/cosmwasm/wasm/v1/authz'
 import { AccessConfig, AccessConfigAmino } from './types'
-import { base64ToBytes, bytesToBase64 } from '../../../utils'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import { Coin, CoinAmino } from '../../../cosmos/base/v1beta1/coin'
 import { Any } from '@initia/initia.proto/google/protobuf/any'
 
@@ -82,13 +82,13 @@ export interface ContractMigrationAuthorizationAmino {
 
 export const CodeGrant = {
   toAmino: (msg: CodeGrant_pb): CodeGrantAmino => ({
-    code_hash: bytesToBase64(msg.codeHash),
+    code_hash: toBase64(msg.codeHash),
     instantiate_permission: msg.instantiatePermission
       ? AccessConfig.toAmino(msg.instantiatePermission)
       : undefined,
   }),
   fromAmino: (msg: CodeGrantAmino): CodeGrant_pb => ({
-    codeHash: base64ToBytes(msg.code_hash),
+    codeHash: fromBase64(msg.code_hash),
     instantiatePermission: msg.instantiate_permission
       ? AccessConfig.fromAmino(msg.instantiate_permission)
       : undefined,
@@ -240,7 +240,7 @@ namespace ContractFilter {
           type: 'wasm/AcceptedMessagesFilter',
           value: {
             messages: acceptedMessagesFilter.messages.map((message) =>
-              bytesToBase64(message)
+              toBase64(message)
             ),
           },
         }
@@ -272,7 +272,7 @@ namespace ContractFilter {
           typeUrl: '/cosmwasm.wasm.v1.AcceptedMessagesFilter',
           value: AcceptedMessagesFilter.encode({
             messages: msg.value.messages.map((message) =>
-              base64ToBytes(message)
+              fromBase64(message)
             ),
           }).finish(),
         }

--- a/src/opinit/opchild/v1/tx.ts
+++ b/src/opinit/opchild/v1/tx.ts
@@ -23,11 +23,8 @@ import {
 } from './tx.aminoTypes'
 import { Coin } from '../../../cosmos/base/v1beta1/coin'
 import { Coin as Coin_pb } from '@initia/initia.proto/cosmos/base/v1beta1/coin'
-import {
-  base64ToBytes,
-  bytesToBase64,
-  createMsgConverter,
-} from '../../../utils'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
+import { createMsgConverter } from '../../../utils'
 import {
   BridgeInfo as BridgeInfo_pb,
   Params as Params_pb,
@@ -59,7 +56,7 @@ export const aminoConverters: AminoConverters = {
       sequence: msg.sequence.toString(),
       height: msg.height.toString(),
       base_denom: msg.baseDenom,
-      data: msg.data.length === 0 ? undefined : bytesToBase64(msg.data),
+      data: msg.data.length === 0 ? undefined : toBase64(msg.data),
     }),
     fromAmino: (
       msg: MsgFinalizeTokenDepositAmino
@@ -71,7 +68,7 @@ export const aminoConverters: AminoConverters = {
       sequence: BigInt(msg.sender),
       height: BigInt(msg.height),
       baseDenom: msg.base_denom,
-      data: msg.data ? base64ToBytes(msg.data) : new Uint8Array([]),
+      data: msg.data ? fromBase64(msg.data) : new Uint8Array([]),
     }),
   },
 
@@ -139,12 +136,12 @@ export const aminoConverters: AminoConverters = {
     toAmino: (msg: MsgUpdateOracle): MsgUpdateOracleAmino => ({
       sender: msg.sender,
       height: msg.height.toString(),
-      data: msg.data.length === 0 ? undefined : bytesToBase64(msg.data),
+      data: msg.data.length === 0 ? undefined : toBase64(msg.data),
     }),
     fromAmino: (msg: MsgUpdateOracleAmino): MsgUpdateOracle => ({
       sender: msg.sender,
       height: BigInt(msg.height),
-      data: msg.data ? base64ToBytes(msg.data) : new Uint8Array([]),
+      data: msg.data ? fromBase64(msg.data) : new Uint8Array([]),
     }),
   },
 

--- a/src/opinit/ophost/v1/tx.ts
+++ b/src/opinit/ophost/v1/tx.ts
@@ -31,7 +31,7 @@ import {
 } from './tx.aminoTypes'
 import { Coin } from '../../../cosmos/base/v1beta1/coin'
 import { Coin as Coin_pb } from '@initia/initia.proto/cosmos/base/v1beta1/coin'
-import { base64ToBytes, bytesToBase64 } from '../../../utils'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import { BatchInfo, BridgeConfig, Params } from './types'
 import {
   BatchInfo as BatchInfo_pb,
@@ -64,13 +64,13 @@ export const aminoConverters: AminoConverters = {
       submitter: msg.submitter,
       bridge_id: msg.bridgeId.toString(),
       batch_bytes:
-        msg.batchBytes.length === 0 ? undefined : bytesToBase64(msg.batchBytes),
+        msg.batchBytes.length === 0 ? undefined : toBase64(msg.batchBytes),
     }),
     fromAmino: (msg: MsgRecordBatchAmino): MsgRecordBatch => ({
       submitter: msg.submitter,
       bridgeId: BigInt(msg.bridge_id),
       batchBytes: msg.batch_bytes
-        ? base64ToBytes(msg.batch_bytes)
+        ? fromBase64(msg.batch_bytes)
         : new Uint8Array([]),
     }),
   },
@@ -95,7 +95,7 @@ export const aminoConverters: AminoConverters = {
       output_index: msg.outputIndex.toString(),
       l2_block_number: msg.l2BlockNumber.toString(),
       output_root:
-        msg.outputRoot.length === 0 ? undefined : bytesToBase64(msg.outputRoot),
+        msg.outputRoot.length === 0 ? undefined : toBase64(msg.outputRoot),
     }),
     fromAmino: (msg: MsgProposeOutputAmino): MsgProposeOutput => ({
       proposer: msg.proposer,
@@ -103,7 +103,7 @@ export const aminoConverters: AminoConverters = {
       outputIndex: BigInt(msg.output_index),
       l2BlockNumber: BigInt(msg.l2_block_number),
       outputRoot: msg.output_root
-        ? base64ToBytes(msg.output_root)
+        ? fromBase64(msg.output_root)
         : new Uint8Array([]),
     }),
   },
@@ -129,7 +129,7 @@ export const aminoConverters: AminoConverters = {
       bridge_id: msg.bridgeId.toString(),
       to: msg.to,
       amount: Coin.toAmino(msg.amount as Coin_pb),
-      data: msg.data.length === 0 ? undefined : bytesToBase64(msg.data),
+      data: msg.data.length === 0 ? undefined : toBase64(msg.data),
     }),
     fromAmino: (
       msg: MsgInitiateTokenDepositAmino
@@ -138,7 +138,7 @@ export const aminoConverters: AminoConverters = {
       bridgeId: BigInt(msg.bridge_id),
       to: msg.to,
       amount: Coin.fromAmino(msg.amount),
-      data: msg.data ? base64ToBytes(msg.data) : new Uint8Array([]),
+      data: msg.data ? fromBase64(msg.data) : new Uint8Array([]),
     }),
   },
 
@@ -153,14 +153,14 @@ export const aminoConverters: AminoConverters = {
       withdrawal_proofs:
         msg.withdrawalProofs.length === 0
           ? undefined
-          : msg.withdrawalProofs.map((proof) => bytesToBase64(proof)),
+          : msg.withdrawalProofs.map((proof) => toBase64(proof)),
       from: msg.from,
       to: msg.to,
       sequence: msg.sequence.toString(),
       amount: Coin.toAmino(msg.amount as Coin_pb),
-      version: bytesToBase64(msg.version),
-      storage_root: bytesToBase64(msg.storageRoot),
-      last_block_hash: bytesToBase64(msg.lastBlockHash),
+      version: toBase64(msg.version),
+      storage_root: toBase64(msg.storageRoot),
+      last_block_hash: toBase64(msg.lastBlockHash),
     }),
     fromAmino: (
       msg: MsgFinalizeTokenWithdrawalAmino
@@ -169,15 +169,15 @@ export const aminoConverters: AminoConverters = {
       bridgeId: BigInt(msg.bridge_id),
       outputIndex: BigInt(msg.output_index),
       withdrawalProofs: msg.withdrawal_proofs
-        ? msg.withdrawal_proofs.map((proof) => base64ToBytes(proof))
+        ? msg.withdrawal_proofs.map((proof) => fromBase64(proof))
         : [],
       from: msg.from,
       to: msg.to,
       sequence: BigInt(msg.sequence),
       amount: Coin.fromAmino(msg.amount),
-      version: base64ToBytes(msg.version),
-      storageRoot: base64ToBytes(msg.storage_root),
-      lastBlockHash: base64ToBytes(msg.last_block_hash),
+      version: fromBase64(msg.version),
+      storageRoot: fromBase64(msg.storage_root),
+      lastBlockHash: fromBase64(msg.last_block_hash),
     }),
   },
 
@@ -242,12 +242,12 @@ export const aminoConverters: AminoConverters = {
     toAmino: (msg: MsgUpdateMetadata): MsgUpdateMetadataAmino => ({
       authority: msg.authority,
       bridge_id: msg.bridgeId.toString(),
-      metadata: bytesToBase64(msg.metadata),
+      metadata: toBase64(msg.metadata),
     }),
     fromAmino: (msg: MsgUpdateMetadataAmino): MsgUpdateMetadata => ({
       authority: msg.authority,
       bridgeId: BigInt(msg.bridge_id),
-      metadata: base64ToBytes(msg.metadata),
+      metadata: fromBase64(msg.metadata),
     }),
   },
 

--- a/src/opinit/ophost/v1/types.ts
+++ b/src/opinit/ophost/v1/types.ts
@@ -7,7 +7,7 @@ import {
 } from '@initia/opinit.proto/opinit/ophost/v1/types'
 import { Duration, DurationAmino } from '../../../google/protobuf/duration'
 import { Duration as Duration_pb } from '@initia/initia.proto/google/protobuf/duration'
-import { base64ToBytes, bytesToBase64 } from '../../../utils'
+import { fromBase64, toBase64 } from '@cosmjs/encoding'
 import { Coin, CoinAmino } from '../../../cosmos/base/v1beta1/coin'
 
 export const BridgeConfig = {
@@ -26,7 +26,7 @@ export const BridgeConfig = {
     metadata:
       bridgeConfig.metadata.length === 0
         ? undefined
-        : bytesToBase64(bridgeConfig.metadata),
+        : toBase64(bridgeConfig.metadata),
   }),
   fromAmino: (bridgeConfig: BridgeConfigAmino): BridgeConfig_pb => ({
     challenger: bridgeConfig.challenger,
@@ -37,7 +37,7 @@ export const BridgeConfig = {
     submissionStartHeight: BigInt(bridgeConfig.submission_start_height),
     oracleEnabled: bridgeConfig.oracle_enabled,
     metadata: bridgeConfig.metadata
-      ? base64ToBytes(bridgeConfig.metadata)
+      ? fromBase64(bridgeConfig.metadata)
       : new Uint8Array([]),
   }),
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,22 +3,6 @@ import { MsgAmino, MsgConverter } from '../types'
 import { Any } from '@initia/initia.proto/google/protobuf/any'
 import { GeneratedType } from '@cosmjs/proto-signing'
 
-// base64 convert
-export function bytesToBase64(uint8Array: Uint8Array) {
-  const binaryString = String.fromCharCode(...uint8Array)
-  return btoa(binaryString)
-}
-
-export function base64ToBytes(base64Str: string) {
-  const binaryString = atob(base64Str)
-
-  const uint8Array = new Uint8Array(binaryString.length)
-  for (let i = 0; i < binaryString.length; i++) {
-    uint8Array[i] = binaryString.charCodeAt(i)
-  }
-  return uint8Array
-}
-
 export function createMsgConverter(
   registry: readonly [string, GeneratedType][],
   aminoConverters: AminoConverters


### PR DESCRIPTION
## Summary

`bytesToBase64` used `String.fromCharCode(...uint8Array)`, which throws `Maximum call stack size exceeded` once the byte array exceeds the JS engine's argument limit (V8 ~125k, JavaScriptCore ~65k, SpiderMonkey ~500k).

This breaks real-world cases such as:
- `MsgPublish.code_bytes` when publishing multiple modules at once
- `MsgExecute.args` carrying large BCS buffers — e.g. multisig's `multisig_v2::create_proposal_with_json` packs the entire inner JSON message into `args[5]` (BCS `vector<vector<string>>`), easily reaching hundreds of KB

## Changes

- Remove `bytesToBase64` / `base64ToBytes` from `src/utils`
- Replace all call sites with `toBase64` / `fromBase64` from `@cosmjs/encoding` (backed by `base64-js`, byte-by-byte, no spread)
- Add `@cosmjs/encoding ^0.36.0` to both `dependencies` and `peerDependencies` to avoid relying on transitive resolution from `@cosmjs/stargate` (breaks under strict pnpm when not hoisted)
- Bump version to 1.0.19

## Test plan

- [x] `npm run build` passes
- [ ] Manual sanity check: encode/decode round-trip for a >200KB `Uint8Array`
- [ ] Verify multisig `create_proposal_with_json` flow no longer throws

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.0.19
  * Added `@cosmjs/encoding` dependency for enhanced base64 encoding and decoding support across crypto and transaction modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->