### PR TITLE
fix: decode opchild MsgFinalizeTokenDeposit sequence from msg.sequence

### DIFF
--- a/src/opinit/opchild/v1/tx.ts
+++ b/src/opinit/opchild/v1/tx.ts
@@ -68,7 +68,7 @@ export const aminoConverters: AminoConverters = {
       from: msg.from,
       to: msg.to,
       amount: Coin.fromAmino(msg.amount),
-      sequence: BigInt(msg.sender),
+      sequence: BigInt(msg.sequence),
       height: BigInt(msg.height),
       baseDenom: msg.base_denom,
       data: msg.data ? base64ToBytes(msg.data) : new Uint8Array([]),


### PR DESCRIPTION
## Summary

- `MsgFinalizeTokenDeposit.fromAmino` was reading `sequence` from `msg.sender`, an address string. `BigInt()` then throws `SyntaxError` at runtime whenever this message is decoded.
- Switch the field to `msg.sequence` so amino → proto decoding mirrors the inverse `toAmino`.

Found via CodeRabbit out-of-diff review on #27.

## Test plan

- [ ] Run a `MsgFinalizeTokenDeposit` round-trip (`toAmino` → `fromAmino`) with a non-numeric `sender` and a numeric `sequence` and confirm no throw and the field round-trips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect field assignment in token deposit finalization that was causing sequence values to be mishandled during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->